### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/pr_push_validation.yml
+++ b/.github/workflows/pr_push_validation.yml
@@ -14,9 +14,9 @@ jobs:
         python: ["3.11"]
     name: Building env and linting Python ${{ matrix.python }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install Poetry


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

Third-party actions in `.github/workflows` are pinned to immutable commit
SHAs to protect against supply-chain tampering on mutable tags/branches.
The original ref is preserved as a trailing comment.

**Summary**
- 2 action references pinned across 1 workflow files

---
🤖 Automated PR — generated by gh-actions-pinner.
